### PR TITLE
Fix inverted date filtering logic in load_gee_as_image()

### DIFF
--- a/skiba/aggregated_point_extraction.py
+++ b/skiba/aggregated_point_extraction.py
@@ -231,10 +231,8 @@ class AggregatedPointExtraction:
         elif data_str == "image_collection":
             col = ee.ImageCollection(dataset_id)
             # If date filters are provided, apply them
-            if start_date is None and end_date is None:
+            if start_date is not None and end_date is not None:
                 col = col.filterDate(start_date, end_date)
-            else:
-                pass
             # Reduce to a single image (e.g., median composite)
             img = col.median()
             return img

--- a/skiba/buffer_method.py
+++ b/skiba/buffer_method.py
@@ -165,10 +165,8 @@ class buffer_method:
             else:
                 raise ValueError("Dataset ID is not a valid Image or ImageCollection.")
 
-            if start_date is None and end_date is None:
+            if start_date is not None and end_date is not None:
                 col = col.filterDate(start_date, end_date)
-            else:
-                pass
 
             zonal_stats = col.median().reduceRegion(
                 reducer=ee.Reducer.median(), geometry=fc.geometry()
@@ -300,10 +298,8 @@ class buffer_method:
         elif data_str == "image_collection":
             col = ee.ImageCollection(dataset_id)
             # If date filters are provided, apply them
-            if start_date is None and end_date is None:
+            if start_date is not None and end_date is not None:
                 col = col.filterDate(start_date, end_date)
-            else:
-                pass
             # Reduce to a single image (e.g., median composite)
             img = col.median()
             return img

--- a/skiba/point_extraction.py
+++ b/skiba/point_extraction.py
@@ -223,10 +223,8 @@ class PointExtraction:
         elif data_str == "image_collection":
             col = ee.ImageCollection(dataset_id)
             # If date filters are provided, apply them
-            if start_date is None and end_date is None:
+            if start_date is not None and end_date is not None:
                 col = col.filterDate(start_date, end_date)
-            else:
-                pass
             # Reduce to a single image (e.g., median composite)
             img = col.median()
             return img


### PR DESCRIPTION
## Summary

- Fixed inverted conditional logic for date filtering in `load_gee_as_image()` functions

## Problem

The date filtering logic was inverted - filters were being applied when dates were `None` rather than when they were provided:

```python
# Before (incorrect)
if start_date is None and end_date is None:
    col = col.filterDate(start_date, end_date)
else:
    pass
```

This caused:
- Date filters to be ignored when users specified date ranges
- Attempts to filter with `None` values when no dates were provided

## Solution

```python
# After (correct)
if start_date is not None and end_date is not None:
    col = col.filterDate(start_date, end_date)
```

## Files Changed

- `skiba/point_extraction.py`
- `skiba/aggregated_point_extraction.py`
- `skiba/buffer_method.py`

## Testing

The fix is straightforward logic correction. Date filtering now works as expected:
- When dates are provided → filter is applied
- When dates are not provided → no filtering (uses full time range)

Fixes #75